### PR TITLE
Add a unique check when fetching collectionids from client and fix struct types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=novisto
 NAME=bitwarden
 BINARY=terraform-provider-${NAME}
-VERSION=0.1.0
+VERSION=0.2.1
 OS_ARCH=linux_amd64
 
 default: install

--- a/bitwarden/client.go
+++ b/bitwarden/client.go
@@ -1,6 +1,7 @@
 package bitwarden
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -74,9 +75,12 @@ func PrepareSecureNoteCreate(secureNote SecureNote) ItemCreate {
 		reprompt = 1
 	}
 
+	var collectionIDs []string
+	secureNote.CollectionIDs.ElementsAs(context.TODO(), collectionIDs, false)
+
 	return ItemCreate{
 		OrganizationId: secureNote.OrganizationId.Value,
-		CollectionIDs:  secureNote.CollectionIDs,
+		CollectionIDs:  collectionIDs,
 		FolderID:       folderId,
 		Type:           2,
 		Name:           secureNote.Name.Value,
@@ -160,7 +164,15 @@ func (c *Client) UpdateSecureNote(id string, secureNote SecureNote) (*Item, erro
 	RandSleep(5)
 
 	out, err := RunCommand(
-		"bw", "edit", "item", id, "--organizationid", secureNote.OrganizationId.Value, b64payload, "--session", c.Session,
+		"bw",
+		"edit",
+		"item",
+		id,
+		"--organizationid",
+		secureNote.OrganizationId.Value,
+		b64payload,
+		"--session",
+		c.Session,
 	)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("%s\n%s", out, err))
@@ -189,6 +201,9 @@ func (c *Client) GetItem(id string) (*Item, error) {
 		return nil, err
 	}
 
+	// This is a fix for BW cli that returns duplicated values for collectionIDs
+	decoded.CollectionIDs = unique(decoded.CollectionIDs)
+
 	return &decoded, nil
 }
 
@@ -212,4 +227,19 @@ func (c *Client) DeleteItem(id string) error {
 	}
 
 	return nil
+}
+
+func unique(slice []string) []string {
+	// create a map with all the values as key
+	uniqMap := make(map[string]struct{})
+	for _, v := range slice {
+		uniqMap[v] = struct{}{}
+	}
+
+	// turn the map keys into a slice
+	uniqSlice := make([]string, 0, len(uniqMap))
+	for v := range uniqMap {
+		uniqSlice = append(uniqSlice, v)
+	}
+	return uniqSlice
 }

--- a/bitwarden/client.go
+++ b/bitwarden/client.go
@@ -202,7 +202,7 @@ func (c *Client) GetItem(id string) (*Item, error) {
 	}
 
 	// This is a fix for BW cli that returns duplicated values for collectionIDs
-	decoded.CollectionIDs = unique(decoded.CollectionIDs)
+	decoded.CollectionIDs = Unique(decoded.CollectionIDs)
 
 	return &decoded, nil
 }
@@ -227,19 +227,4 @@ func (c *Client) DeleteItem(id string) error {
 	}
 
 	return nil
-}
-
-func unique(slice []string) []string {
-	// create a map with all the values as key
-	uniqMap := make(map[string]struct{})
-	for _, v := range slice {
-		uniqMap[v] = struct{}{}
-	}
-
-	// turn the map keys into a slice
-	uniqSlice := make([]string, 0, len(uniqMap))
-	for v := range uniqMap {
-		uniqSlice = append(uniqSlice, v)
-	}
-	return uniqSlice
 }

--- a/bitwarden/models.go
+++ b/bitwarden/models.go
@@ -13,6 +13,6 @@ type SecureNote struct {
 	Name           types.String `tfsdk:"name"`
 	Notes          types.String `tfsdk:"notes"`
 	Favorite       types.Bool   `tfsdk:"favorite"`
-	CollectionIDs  []string     `tfsdk:"collection_ids"`
+	CollectionIDs  types.List   `tfsdk:"collection_ids"`
 	RevisionDate   types.String `tfsdk:"revision_date"`
 }

--- a/bitwarden/utils.go
+++ b/bitwarden/utils.go
@@ -17,3 +17,18 @@ func RunCommand(commandName string, args ...string) (string, error) {
 func RandSleep(maxSeconds int) {
 	time.Sleep(time.Duration(rand.Intn(maxSeconds)) * time.Second)
 }
+
+func Unique(slice []string) []string {
+	// create a map with all the values as key
+	uniqMap := make(map[string]struct{})
+	for _, v := range slice {
+		uniqMap[v] = struct{}{}
+	}
+
+	// turn the map keys into a slice
+	uniqSlice := make([]string, 0, len(uniqMap))
+	for v := range uniqMap {
+		uniqSlice = append(uniqSlice, v)
+	}
+	return uniqSlice
+}


### PR DESCRIPTION
This fixes an issue with the Bitwarden CLI Client that returns duplicated IDs in the collectionIDs array.

Also changed type of collectionIDs to a list of string in terraform struct.